### PR TITLE
Enable user to add a script after editing one

### DIFF
--- a/webapp/channel_setting.js
+++ b/webapp/channel_setting.js
@@ -247,6 +247,8 @@ $('#addScriptNotifierButton').click(
     $('#scriptNotifierDailyMinute').val(0);
 
     scriptNotifierTypeChange();
+
+    editScriptNotifierIndex = null;
   }
 );
 
@@ -407,6 +409,8 @@ $('#addScriptProcessorButton').click(
 
     // 初期化
     $('#scriptProcessorText').val('');
+
+    editScriptProcessorIndex = null;
   }
 );
 


### PR DESCRIPTION
Fix the following issue occurred in the channel settings.

When a user try to add a cyclic script, ScriptNotifier, after editing the
other scripts, he/she sees that a new script is not added and existing one
is replaced.

The same problem is occurred for ScriptProcessor.
